### PR TITLE
Performance optimization for expensive *:* liveness check queries

### DIFF
--- a/solr/core/src/java/org/apache/solr/core/SolrCore.java
+++ b/solr/core/src/java/org/apache/solr/core/SolrCore.java
@@ -193,7 +193,6 @@ public final class SolrCore implements SolrInfoBean, SolrMetricProducer, Closeab
   private static final Logger log = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
   private static final Logger requestLog = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass().getName() + ".Request"); //nowarn
   private static final Logger slowLog = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass().getName() + ".SlowRequest"); //nowarn
-  private static final Logger livenessCheckLog = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass().getName() + ".LivenessCheckRequest"); //nowarn
 
   private String name;
   private String logid; // used to show what name is set
@@ -2654,12 +2653,13 @@ public final class SolrCore implements SolrInfoBean, SolrMetricProducer, Closeab
       if (requestLog.isInfoEnabled()) {
         requestLog.info(rsp.getToLogAsString(logid));
       }
-      if(livenessCheckLog.isInfoEnabled()) {
+
+      if(requestLog.isWarnEnabled()) {
         SolrRequestInfo requestInfo = SolrRequestInfo.getRequestInfo();
-        if(requestInfo != null){
+        if (requestInfo != null) {
           ResponseBuilder rb = requestInfo.getResponseBuilder();
-          if(rb !=null && QueryComponent.isLivenessCheck(rb, req)){
-            livenessCheckLog.info(rsp.getToLogAsString(logid));
+          if (rb != null && QueryComponent.isLivenessCheck(rb, req)) {
+            requestLog.warn(rsp.getToLogAsString(logid));
           }
         }
       }

--- a/solr/core/src/java/org/apache/solr/core/SolrCore.java
+++ b/solr/core/src/java/org/apache/solr/core/SolrCore.java
@@ -108,6 +108,8 @@ import org.apache.solr.handler.ReplicationHandler;
 import org.apache.solr.handler.RequestHandlerBase;
 import org.apache.solr.handler.SolrConfigHandler;
 import org.apache.solr.handler.component.HighlightComponent;
+import org.apache.solr.handler.component.QueryComponent;
+import org.apache.solr.handler.component.ResponseBuilder;
 import org.apache.solr.handler.component.SearchComponent;
 import org.apache.solr.logging.MDCLoggingContext;
 import org.apache.solr.metrics.SolrCoreMetricManager;
@@ -116,6 +118,7 @@ import org.apache.solr.metrics.SolrMetricsContext;
 import org.apache.solr.pkg.*;
 import org.apache.solr.request.SolrQueryRequest;
 import org.apache.solr.request.SolrRequestHandler;
+import org.apache.solr.request.SolrRequestInfo;
 import org.apache.solr.response.BinaryResponseWriter;
 import org.apache.solr.response.CSVResponseWriter;
 import org.apache.solr.response.GeoJSONResponseWriter;
@@ -190,6 +193,7 @@ public final class SolrCore implements SolrInfoBean, SolrMetricProducer, Closeab
   private static final Logger log = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
   private static final Logger requestLog = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass().getName() + ".Request"); //nowarn
   private static final Logger slowLog = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass().getName() + ".SlowRequest"); //nowarn
+  private static final Logger livenessCheckLog = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass().getName() + ".LivenessCheckRequest"); //nowarn
 
   private String name;
   private String logid; // used to show what name is set
@@ -2649,6 +2653,15 @@ public final class SolrCore implements SolrInfoBean, SolrMetricProducer, Closeab
     if (rsp.getToLog().size() > 0) {
       if (requestLog.isInfoEnabled()) {
         requestLog.info(rsp.getToLogAsString(logid));
+      }
+      if(livenessCheckLog.isInfoEnabled()) {
+        SolrRequestInfo requestInfo = SolrRequestInfo.getRequestInfo();
+        if(requestInfo != null){
+          ResponseBuilder rb = requestInfo.getResponseBuilder();
+          if(rb !=null && QueryComponent.isLivenessCheck(rb, req)){
+            livenessCheckLog.info(rsp.getToLogAsString(logid));
+          }
+        }
       }
 
       /* slowQueryThresholdMillis defaults to -1 in SolrConfig -- not enabled.*/

--- a/solr/core/src/java/org/apache/solr/handler/component/QueryComponent.java
+++ b/solr/core/src/java/org/apache/solr/handler/component/QueryComponent.java
@@ -241,6 +241,13 @@ public class QueryComponent extends SearchComponent
     //params={q=*:*&distrib=false&sort=_docid_+asc&rows=0&wt=javabin&version=2}
     // this is the syntax of liveness check query fired by LBSolrClient
     // this may take a lot of time for a large index. So we rewrite it to MatchNoDocsQuery
+    if(isLivenessCheck(rb, req)){
+      log.info("zombie live check query rewritten {}", req.getParamString());
+      rb.setQuery(new MatchNoDocsQuery());
+    };
+  }
+
+  public static boolean isLivenessCheck(ResponseBuilder rb, SolrQueryRequest req) {
     if (rb.getQuery() instanceof MatchAllDocsQuery) {
       SortSpec sort = rb.getSortSpec();
       if (sort != null) {
@@ -253,11 +260,11 @@ public class QueryComponent extends SearchComponent
             req.getParams().get("facet") == null &&
             "false".equals(req.getParams().get("distrib"))
         ) {
-          log.info("zombie live check query rewritten {}", req.getParamString());
-          rb.setQuery(new MatchNoDocsQuery());
+          return true;
         }
       }
     }
+    return false;
   }
 
   protected void prepareGrouping(ResponseBuilder rb) throws IOException {

--- a/solr/core/src/java/org/apache/solr/handler/component/QueryComponent.java
+++ b/solr/core/src/java/org/apache/solr/handler/component/QueryComponent.java
@@ -250,6 +250,7 @@ public class QueryComponent extends SearchComponent
             req.getParams().get("facet") == null &&
             "false".equals(req.getParams().get("distrib"))
         ) {
+          log.info("zombie live check query rewritten {}", req.getParamString());
           rb.setQuery(new MatchNoDocsQuery());
         }
       }

--- a/solr/core/src/java/org/apache/solr/handler/component/QueryComponent.java
+++ b/solr/core/src/java/org/apache/solr/handler/component/QueryComponent.java
@@ -238,6 +238,9 @@ public class QueryComponent extends SearchComponent
   }
 
   private static void checkAliveCheckQuery(ResponseBuilder rb, SolrQueryRequest req) {
+    //params={q=*:*&distrib=false&sort=_docid_+asc&rows=0&wt=javabin&version=2}
+    // this is the syntax of liveness check query fired by LBSolrClient
+    // this may take a lot of time for a large index. So we rewrite it to MatchNoDocsQuery
     if (rb.getQuery() instanceof MatchAllDocsQuery) {
       SortSpec sort = rb.getSortSpec();
       if (sort != null) {

--- a/solr/core/src/java/org/apache/solr/handler/component/QueryComponent.java
+++ b/solr/core/src/java/org/apache/solr/handler/component/QueryComponent.java
@@ -234,10 +234,6 @@ public class QueryComponent extends SearchComponent
     if (rb.getSortSpec().getOffset() < 0) {
       throw new SolrException(SolrException.ErrorCode.BAD_REQUEST, "'start' parameter cannot be negative");
     }
-    checkAliveCheckQuery(rb, req);
-  }
-
-  private static void checkAliveCheckQuery(ResponseBuilder rb, SolrQueryRequest req) {
     //params={q=*:*&distrib=false&sort=_docid_+asc&rows=0&wt=javabin&version=2}
     // this is the syntax of liveness check query fired by LBSolrClient
     // this may take a lot of time for a large index. So we rewrite it to MatchNoDocsQuery

--- a/solr/core/src/java/org/apache/solr/handler/component/QueryComponent.java
+++ b/solr/core/src/java/org/apache/solr/handler/component/QueryComponent.java
@@ -115,8 +115,6 @@ import org.apache.solr.util.SolrPluginUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import static org.apache.solr.common.params.CommonParams.DISTRIB;
-import static org.apache.solr.common.params.CommonParams.ROWS;
 
 
 /**
@@ -255,9 +253,9 @@ public class QueryComponent extends SearchComponent
             rb.getFilters() == null &&
             rb.getCursorMark() == null &&
             rb.getGroupingSpec() == null &&
-            "0".equals(req.getParams().get(ROWS)) &&
+            "0".equals(req.getParams().get(CommonParams.ROWS)) &&
             req.getParams().get("facet") == null &&
-            "false".equals(req.getParams().get(DISTRIB))
+            "false".equals(req.getParams().get(CommonParams.DISTRIB))
         ) {
           return true;
         }
@@ -778,10 +776,10 @@ public class QueryComponent extends SearchComponent
     // we could just specify that this is a shard request.
     if(rb.shards_rows > -1) {
       // if the client set shards.rows set this explicity
-      sreq.params.set(ROWS,rb.shards_rows);
+      sreq.params.set(CommonParams.ROWS,rb.shards_rows);
     } else {
       // what if rows<0 as it is allowed for grouped request??
-      sreq.params.set(ROWS, rb.getSortSpec().getOffset() + rb.getSortSpec().getCount());
+      sreq.params.set(CommonParams.ROWS, rb.getSortSpec().getOffset() + rb.getSortSpec().getCount());
     }
 
     sreq.params.set(ResponseBuilder.FIELD_SORT_VALUES,"true");

--- a/solr/core/src/java/org/apache/solr/handler/component/QueryComponent.java
+++ b/solr/core/src/java/org/apache/solr/handler/component/QueryComponent.java
@@ -247,9 +247,9 @@ public class QueryComponent extends SearchComponent
   public static boolean isLivenessCheck(ResponseBuilder rb, SolrQueryRequest req) {
     if (rb.getQuery() instanceof MatchAllDocsQuery) {
       SortSpec sort = rb.getSortSpec();
-      if (sort != null && sort.getSort() != null) {
+      if (sort != null && sort.getSort() != null && sort.getSort().getSort().length == 1) {
         if (sort.getSort().getSort().length == 1 &&
-            sort.getSort().getSort()[0].getType().equals(SortField.Type.DOC) &&
+            SortField.Type.DOC.equals(sort.getSort().getSort()[0].getType()) &&
             rb.getFilters() == null &&
             rb.getCursorMark() == null &&
             rb.getGroupingSpec() == null &&

--- a/solr/core/src/java/org/apache/solr/handler/component/QueryComponent.java
+++ b/solr/core/src/java/org/apache/solr/handler/component/QueryComponent.java
@@ -235,11 +235,9 @@ public class QueryComponent extends SearchComponent
     if (rb.getSortSpec().getOffset() < 0) {
       throw new SolrException(SolrException.ErrorCode.BAD_REQUEST, "'start' parameter cannot be negative");
     }
-    //params={q=*:*&distrib=false&sort=_docid_+asc&rows=0&wt=javabin&version=2}
-    // this is the syntax of liveness check query fired by LBSolrClient
-    // this may take a lot of time for a large index. So we rewrite it to MatchNoDocsQuery
+
     if(isLivenessCheck(rb, req)){
-      log.warn("zombie live check query rewritten {}", req.getParamString());
+      if (log.isWarnEnabled()) log.warn("Zombie server's liveliness check query to be rewritten: {}", req.getParamString());
       rb.setQuery(new MatchNoDocsQuery());
     };
   }

--- a/solr/core/src/java/org/apache/solr/handler/component/QueryComponent.java
+++ b/solr/core/src/java/org/apache/solr/handler/component/QueryComponent.java
@@ -246,7 +246,7 @@ public class QueryComponent extends SearchComponent
   public static boolean isLivenessCheck(ResponseBuilder rb, SolrQueryRequest req) {
     if (rb.getQuery() instanceof MatchAllDocsQuery) {
       SortSpec sort = rb.getSortSpec();
-      if (sort != null) {
+      if (sort != null && sort.getSort() != null) {
         if (sort.getSort().getSort().length == 1 &&
             sort.getSort().getSort()[0].getType().equals(SortField.Type.DOC) &&
             rb.getFilters() == null &&

--- a/solr/core/src/java/org/apache/solr/handler/component/QueryComponent.java
+++ b/solr/core/src/java/org/apache/solr/handler/component/QueryComponent.java
@@ -115,6 +115,9 @@ import org.apache.solr.util.SolrPluginUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import static org.apache.solr.common.params.CommonParams.DISTRIB;
+import static org.apache.solr.common.params.CommonParams.ROWS;
+
 
 /**
  * TODO!
@@ -238,7 +241,7 @@ public class QueryComponent extends SearchComponent
     // this is the syntax of liveness check query fired by LBSolrClient
     // this may take a lot of time for a large index. So we rewrite it to MatchNoDocsQuery
     if(isLivenessCheck(rb, req)){
-      log.info("zombie live check query rewritten {}", req.getParamString());
+      log.warn("zombie live check query rewritten {}", req.getParamString());
       rb.setQuery(new MatchNoDocsQuery());
     };
   }
@@ -252,9 +255,9 @@ public class QueryComponent extends SearchComponent
             rb.getFilters() == null &&
             rb.getCursorMark() == null &&
             rb.getGroupingSpec() == null &&
-            "0".equals(req.getParams().get("rows")) &&
+            "0".equals(req.getParams().get(ROWS)) &&
             req.getParams().get("facet") == null &&
-            "false".equals(req.getParams().get("distrib"))
+            "false".equals(req.getParams().get(DISTRIB))
         ) {
           return true;
         }
@@ -775,10 +778,10 @@ public class QueryComponent extends SearchComponent
     // we could just specify that this is a shard request.
     if(rb.shards_rows > -1) {
       // if the client set shards.rows set this explicity
-      sreq.params.set(CommonParams.ROWS,rb.shards_rows);
+      sreq.params.set(ROWS,rb.shards_rows);
     } else {
       // what if rows<0 as it is allowed for grouped request??
-      sreq.params.set(CommonParams.ROWS, rb.getSortSpec().getOffset() + rb.getSortSpec().getCount());
+      sreq.params.set(ROWS, rb.getSortSpec().getOffset() + rb.getSortSpec().getCount());
     }
 
     sreq.params.set(ResponseBuilder.FIELD_SORT_VALUES,"true");

--- a/solr/core/src/java/org/apache/solr/handler/component/QueryComponent.java
+++ b/solr/core/src/java/org/apache/solr/handler/component/QueryComponent.java
@@ -39,6 +39,7 @@ import org.apache.lucene.index.Term;
 import org.apache.lucene.search.FieldComparator;
 import org.apache.lucene.search.FuzzyTermsEnum;
 import org.apache.lucene.search.LeafFieldComparator;
+import org.apache.lucene.search.MatchAllDocsQuery;
 import org.apache.lucene.search.MatchNoDocsQuery;
 import org.apache.lucene.search.Query;
 import org.apache.lucene.search.Scorable;
@@ -232,6 +233,26 @@ public class QueryComponent extends SearchComponent
     //Input validation.
     if (rb.getSortSpec().getOffset() < 0) {
       throw new SolrException(SolrException.ErrorCode.BAD_REQUEST, "'start' parameter cannot be negative");
+    }
+    checkAliveCheckQuery(rb, req);
+  }
+
+  private static void checkAliveCheckQuery(ResponseBuilder rb, SolrQueryRequest req) {
+    if (rb.getQuery() instanceof MatchAllDocsQuery) {
+      SortSpec sort = rb.getSortSpec();
+      if (sort != null) {
+        if (sort.getSort().getSort().length == 1 &&
+            sort.getSort().getSort()[0].getType().equals(SortField.Type.DOC) &&
+            rb.getFilters() == null &&
+            rb.getCursorMark() == null &&
+            rb.getGroupingSpec() == null &&
+            "0".equals(req.getParams().get("rows")) &&
+            req.getParams().get("facet") == null &&
+            "false".equals(req.getParams().get("distrib"))
+        ) {
+          rb.setQuery(new MatchNoDocsQuery());
+        }
+      }
     }
   }
 


### PR DESCRIPTION
At Solr servers, rewriting all liveness check queries sent by the LBSolrClients from a MatchAllDocsQuery to a MatchNoDocsQuery.